### PR TITLE
Change the host display on CLI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ async function run() {
     // create and start server
     const server = createHttpServer();
     server.listen(port, () => {
-        const localUri = `http://127.0.0.1:${port}`;
+        const localUri = `http://0.0.0.0:${port}`;
 
         console.log('🏄', 'Swagger UI running:');
         console.log(`   * ${localUri}`);


### PR DESCRIPTION
Hi maintainers,

According to [NodeJs docs](https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback), if we omit `host` option, the server will use the default `0.0.0.0`. So I open a PR to correct it 😸 .