### PR TITLE
 Fix  Swagger UI OAuth2 Redirect URL with parameters  return  404 Response.

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -163,8 +163,9 @@ export default (): RequestListener => {
                     }
                 }
 
+                const pathname = relUrl.substring(0, relUrl.indexOf('?') < 0 ? relUrl.length : relUrl.indexOf('?'))
                 const file = path.resolve(
-                    path.join(swaggerUIDir, relUrl)
+                    path.join(swaggerUIDir, pathname)
                 );
 
                 let cacheEntry = fileCache[file];

--- a/src/request.ts
+++ b/src/request.ts
@@ -163,7 +163,7 @@ export default (): RequestListener => {
                     }
                 }
 
-                const pathname = relUrl.substring(0, relUrl.indexOf('?') < 0 ? relUrl.length : relUrl.indexOf('?'))
+                const pathname = relUrl.substring(0, relUrl.indexOf("?") < 0 ? relUrl.length : relUrl.indexOf("?"));
                 const file = path.resolve(
                     path.join(swaggerUIDir, pathname)
                 );


### PR DESCRIPTION
Hi maintainers,

Swagger UI OAuth2 Redirect URL  without parameters is work. But  OAuth2 Redirect URL with parameters return 404 Response.
I fixed OAuth2 Redirect URL with parameters return 404 Response. 

URL: http://127.0.0.1:8080/oauth2-redirect.html

![圖片](https://user-images.githubusercontent.com/6058558/192785760-829d3542-c610-45d0-991a-b4e9b78cc9ae.png)

After I fixed this problem.

![圖片](https://user-images.githubusercontent.com/6058558/192785965-4ae52c85-25ae-46cd-9f2c-fa643427b51a.png)

I hope that this tool install from  npm ,  So I open a PR to correct it. 😄 

Attached is the information:
- I enable Chrome CORS.  Reference: [Disable-web-security in Chrome 48+ - Stack Overflow](https://stackoverflow.com/questions/35432749/disable-web-security-in-chrome-48)
- [Line OAuth2 Profile OpenAPI](https://gist.github.com/malagege/8e8299f1fd2af8a6ae44a4e643983ea4)